### PR TITLE
Interpolates messages with variables

### DIFF
--- a/lib/assets/main.js
+++ b/lib/assets/main.js
@@ -36,6 +36,11 @@ export function init(ctx, payload) {
                 <a href="https://api.slack.com/tutorials/tracks/getting-a-token" target="_blank">create a Slack app and get your app's token</a>.
               </p>
             </div>
+            <div class="section">
+              <p>
+                To dynamically inject values into the query use double curly braces, like {{name}}.
+              </p>
+            </div>
           </div>
           <div class="row">
             <div class="field grow">

--- a/lib/kino_slack/message_cell.ex
+++ b/lib/kino_slack/message_cell.ex
@@ -49,6 +49,7 @@ defmodule KinoSlack.MessageCell do
   @impl true
   def to_source(attrs) do
     required_fields = ~w(token_secret_name channel message)
+    interpolated_message = interpolate(attrs["message"])
 
     if all_fields_filled?(attrs, required_fields) do
       quote do
@@ -63,7 +64,7 @@ defmodule KinoSlack.MessageCell do
             url: "/chat.postMessage",
             json: %{
               channel: unquote(attrs["channel"]),
-              text: unquote(attrs["message"])
+              text: unquote(interpolated_message)
             }
           )
 
@@ -78,7 +79,24 @@ defmodule KinoSlack.MessageCell do
     end
   end
 
-  def all_fields_filled?(attrs, keys) do
+  defp interpolate(message) do
+    ~r/(?<before_interpolation>){{[^}]+}}(?<after_interpolation>)/
+    |> Regex.split(message, on: [:before_interpolation, :after_interpolation])
+    |> Enum.map(fn message_chunk ->
+      case Regex.named_captures(~r/{{(?<var_name>.*)}}/, message_chunk) do
+        %{"var_name" => var_name} ->
+          "\#{#{var_name}}"
+
+        _ ->
+          message_chunk
+      end
+    end)
+    |> Enum.join()
+    |> then(fn message -> "\"" <> message <> "\"" end)
+    |> Code.string_to_quoted!()
+  end
+
+  defp all_fields_filled?(attrs, keys) do
     Enum.all?(keys, fn key -> attrs[key] not in [nil, ""] end)
   end
 end

--- a/lib/kino_slack/message_interpolator.ex
+++ b/lib/kino_slack/message_interpolator.ex
@@ -1,0 +1,60 @@
+defmodule KinoSlack.MessageInterpolator do
+  def interpolate(message) do
+    ast = quote do: <<"">>
+    interpolate(message, ast)
+  end
+
+  defp interpolate("", result_ast) do
+    result_ast
+  end
+
+  defp interpolate("{{" <> rest, ast) do
+    with [inner, rest] <- String.split(rest, "}}", parts: 2),
+         {:ok, expression} <- Code.string_to_quoted(inner) do
+      ast = append_interpolation(ast, expression)
+      interpolate(rest, ast)
+    else
+      _ ->
+        <<char::utf8>> = "{"
+        ast = append_char(ast, char)
+        ast = append_char(ast, char)
+        interpolate(rest, ast)
+    end
+  end
+
+  defp interpolate(<<char::utf8, rest::binary>>, ast) do
+    new_ast = append_char(ast, char)
+    interpolate(rest, new_ast)
+  end
+
+  defp append_interpolation(ast, expression) do
+    interpolation_node = {
+      :"::",
+      [],
+      [
+        {{:., [], [Kernel, :to_string]}, [], [expression]},
+        {:binary, [], Elixir}
+      ]
+    }
+
+    {_, _, args} = ast
+    args = args ++ [interpolation_node]
+
+    {:<<>>, [], args}
+  end
+
+  defp append_char(ast, char) do
+    {_, _, args} = ast
+    last_arg = List.last(args)
+
+    new_args =
+      if is_binary(last_arg) do
+        last_string = last_arg <> <<char::utf8>>
+        List.replace_at(args, -1, last_string)
+      else
+        args ++ [<<char::utf8>>]
+      end
+
+    {:<<>>, [], new_args}
+  end
+end

--- a/lib/kino_slack/message_interpolator.ex
+++ b/lib/kino_slack/message_interpolator.ex
@@ -1,4 +1,6 @@
 defmodule KinoSlack.MessageInterpolator do
+  @moduledoc false
+
   def interpolate(message) do
     ast = quote do: <<"">>
     interpolate(message, ast)

--- a/lib/kino_slack/message_interpolator.ex
+++ b/lib/kino_slack/message_interpolator.ex
@@ -2,7 +2,8 @@ defmodule KinoSlack.MessageInterpolator do
   @moduledoc false
 
   def interpolate(message) do
-    args = build_interpolation_args(message, [])
+    args = build_interpolation_args(message, [""])
+    args = Enum.reverse(args)
     {:<<>>, [], args}
   end
 
@@ -13,21 +14,21 @@ defmodule KinoSlack.MessageInterpolator do
   defp build_interpolation_args("{{" <> rest, args) do
     with [inner, rest] <- String.split(rest, "}}", parts: 2),
          {:ok, expression} <- Code.string_to_quoted(inner) do
-      args = append_interpolation(args, expression)
+      args = add_interpolation(args, expression)
       build_interpolation_args(rest, args)
     else
       _ ->
-        args = append_string(args, "{{")
+        args = add_string(args, "{{")
         build_interpolation_args(rest, args)
     end
   end
 
   defp build_interpolation_args(<<char::utf8, rest::binary>>, args) do
-    args = append_string(args, <<char::utf8>>)
+    args = add_string(args, <<char::utf8>>)
     build_interpolation_args(rest, args)
   end
 
-  defp append_interpolation(args, expression) do
+  defp add_interpolation(args, expression) do
     interpolation_node = {
       :"::",
       [],
@@ -37,17 +38,16 @@ defmodule KinoSlack.MessageInterpolator do
       ]
     }
 
-    args ++ [interpolation_node]
+    [interpolation_node | args]
   end
 
-  defp append_string(args, string) do
-    last_arg = List.last(args)
+  defp add_string(args, string) do
+    [head | tail] = args
 
-    if is_binary(last_arg) do
-      last_string = last_arg <> string
-      List.replace_at(args, -1, last_string)
+    if is_binary(head) do
+      [head <> string | tail]
     else
-      args ++ [string]
+      [string | args]
     end
   end
 end

--- a/lib/kino_slack/message_interpolator.ex
+++ b/lib/kino_slack/message_interpolator.ex
@@ -15,15 +15,13 @@ defmodule KinoSlack.MessageInterpolator do
       interpolate(rest, ast)
     else
       _ ->
-        <<char::utf8>> = "{"
-        ast = append_char(ast, char)
-        ast = append_char(ast, char)
+        ast = append_string(ast, "{{")
         interpolate(rest, ast)
     end
   end
 
   defp interpolate(<<char::utf8, rest::binary>>, ast) do
-    new_ast = append_char(ast, char)
+    new_ast = append_string(ast, <<char::utf8>>)
     interpolate(rest, new_ast)
   end
 
@@ -43,16 +41,16 @@ defmodule KinoSlack.MessageInterpolator do
     {:<<>>, [], args}
   end
 
-  defp append_char(ast, char) do
+  defp append_string(ast, string) do
     {_, _, args} = ast
     last_arg = List.last(args)
 
     new_args =
       if is_binary(last_arg) do
-        last_string = last_arg <> <<char::utf8>>
+        last_string = last_arg <> string
         List.replace_at(args, -1, last_string)
       else
-        args ++ [<<char::utf8>>]
+        args ++ [string]
       end
 
     {:<<>>, [], new_args}

--- a/lib/kino_slack/message_interpolator.ex
+++ b/lib/kino_slack/message_interpolator.ex
@@ -37,7 +37,7 @@ defmodule KinoSlack.MessageInterpolator do
       ]
     }
 
-    {_, _, args} = ast
+    {:<<>>, _, args} = ast
     args = args ++ [interpolation_node]
 
     {:<<>>, [], args}

--- a/test/kino_slack/messsage_interpolator_test.exs
+++ b/test/kino_slack/messsage_interpolator_test.exs
@@ -12,7 +12,7 @@ defmodule KinoSlack.MesssageInterpolatorTest do
     generated_code = Macro.to_string(interpolated_ast)
     {interpolated_message, _} = Code.eval_quoted(interpolated_ast, binding())
 
-    assert generated_code == "\"Hi \#{first_name} \#{last_name}! 🎉\""
+    assert generated_code == ~S/"Hi #{first_name} #{last_name}! 🎉"/
     assert interpolated_message == "Hi Hugo Baraúna! 🎉"
   end
 
@@ -23,20 +23,20 @@ defmodule KinoSlack.MesssageInterpolatorTest do
     generated_code = Macro.to_string(interpolated_ast)
     {interpolated_message, _} = Code.eval_quoted(interpolated_ast, binding())
 
-    assert generated_code == "\"One plus one is: \#{1 + 1}\""
+    assert generated_code == ~S/"One plus one is: #{1 + 1}"/
     assert interpolated_message == "One plus one is: 2"
   end
 
-  test "it interpolates expressions with functinos and vars inside a message" do
-    first_name = "Hugo"
-    message = "Do you {{first_name}}, know {{1 + 1}} ?"
+  test "it interpolates funtion calls inside a message" do
+    sum = fn a, b -> a + b end
+    message = "1 + 1 is: {{sum.(1, 1)}}"
 
     interpolated_ast = Interpolator.interpolate(message)
     generated_code = Macro.to_string(interpolated_ast)
     {interpolated_message, _} = Code.eval_quoted(interpolated_ast, binding())
 
-    assert generated_code == "\"Do you \#{first_name}, know \#{1 + 1} ?\""
-    assert interpolated_message == "Do you Hugo, know 2 ?"
+    assert generated_code == ~S/"1 + 1 is: #{sum.(1, 1)}"/
+    assert interpolated_message == "1 + 1 is: 2"
   end
 
   test "it handles messages with only the beginning of interpolation syntax" do
@@ -47,7 +47,7 @@ defmodule KinoSlack.MesssageInterpolatorTest do
     generated_code = Macro.to_string(interpolated_ast)
     {interpolated_message, _} = Code.eval_quoted(interpolated_ast, binding())
 
-    assert generated_code == "\"hi {{ \#{first_name}\""
+    assert generated_code == ~S/"hi {{ #{first_name}"/
     assert interpolated_message == "hi {{ Hugo"
   end
 end

--- a/test/kino_slack/messsage_interpolator_test.exs
+++ b/test/kino_slack/messsage_interpolator_test.exs
@@ -1,0 +1,45 @@
+defmodule KinoSlack.MesssageInterpolatorTest do
+  use ExUnit.Case, async: true
+
+  alias KinoSlack.MessageInterpolator, as: Interpolator
+
+  test "it interpolates variables inside a message" do
+    first_name = "Hugo"
+    last_name = "Baraúna"
+    message = "Hi {{first_name}} {{last_name}}! 🎉"
+
+    interpolated_ast = Interpolator.interpolate(message)
+    {interpolated_message, _} = Code.eval_quoted(interpolated_ast, binding())
+
+    assert interpolated_message == "Hi Hugo Baraúna! 🎉"
+  end
+
+  test "it interpolates expressons inside a message" do
+    message = "One plus one is: {{1 + 1}}"
+
+    interpolated_ast = Interpolator.interpolate(message)
+    {interpolated_message, _} = Code.eval_quoted(interpolated_ast, binding())
+
+    assert interpolated_message == "One plus one is: 2"
+  end
+
+  test "it interpolates expressions with functinos and vars inside a message" do
+    first_name = "Hugo"
+    message = "Do you {{first_name}}, know {{1 + 1}} ?"
+
+    interpolated_ast = Interpolator.interpolate(message)
+    {interpolated_message, _} = Code.eval_quoted(interpolated_ast, binding())
+
+    assert interpolated_message == "Do you Hugo, know 2 ?"
+  end
+
+  test "it handles messags with only the beginning of interpolation syntax" do
+    first_name = "Hugo"
+    message = "hi {{ {{first_name}}"
+
+    interpolated_ast = Interpolator.interpolate(message)
+    {interpolated_message, _} = Code.eval_quoted(interpolated_ast, binding())
+
+    assert interpolated_message == "hi {{ Hugo"
+  end
+end

--- a/test/kino_slack/messsage_interpolator_test.exs
+++ b/test/kino_slack/messsage_interpolator_test.exs
@@ -33,7 +33,7 @@ defmodule KinoSlack.MesssageInterpolatorTest do
     assert interpolated_message == "Do you Hugo, know 2 ?"
   end
 
-  test "it handles messags with only the beginning of interpolation syntax" do
+  test "it handles messages with only the beginning of interpolation syntax" do
     first_name = "Hugo"
     message = "hi {{ {{first_name}}"
 

--- a/test/kino_slack/messsage_interpolator_test.exs
+++ b/test/kino_slack/messsage_interpolator_test.exs
@@ -9,8 +9,10 @@ defmodule KinoSlack.MesssageInterpolatorTest do
     message = "Hi {{first_name}} {{last_name}}! 🎉"
 
     interpolated_ast = Interpolator.interpolate(message)
+    generated_code = Macro.to_string(interpolated_ast)
     {interpolated_message, _} = Code.eval_quoted(interpolated_ast, binding())
 
+    assert generated_code == "\"Hi \#{first_name} \#{last_name}! 🎉\""
     assert interpolated_message == "Hi Hugo Baraúna! 🎉"
   end
 
@@ -18,8 +20,10 @@ defmodule KinoSlack.MesssageInterpolatorTest do
     message = "One plus one is: {{1 + 1}}"
 
     interpolated_ast = Interpolator.interpolate(message)
+    generated_code = Macro.to_string(interpolated_ast)
     {interpolated_message, _} = Code.eval_quoted(interpolated_ast, binding())
 
+    assert generated_code == "\"One plus one is: \#{1 + 1}\""
     assert interpolated_message == "One plus one is: 2"
   end
 
@@ -28,8 +32,10 @@ defmodule KinoSlack.MesssageInterpolatorTest do
     message = "Do you {{first_name}}, know {{1 + 1}} ?"
 
     interpolated_ast = Interpolator.interpolate(message)
+    generated_code = Macro.to_string(interpolated_ast)
     {interpolated_message, _} = Code.eval_quoted(interpolated_ast, binding())
 
+    assert generated_code == "\"Do you \#{first_name}, know \#{1 + 1} ?\""
     assert interpolated_message == "Do you Hugo, know 2 ?"
   end
 
@@ -38,8 +44,10 @@ defmodule KinoSlack.MesssageInterpolatorTest do
     message = "hi {{ {{first_name}}"
 
     interpolated_ast = Interpolator.interpolate(message)
+    generated_code = Macro.to_string(interpolated_ast)
     {interpolated_message, _} = Code.eval_quoted(interpolated_ast, binding())
 
+    assert generated_code == "\"hi {{ \#{first_name}\""
     assert interpolated_message == "hi {{ Hugo"
   end
 end


### PR DESCRIPTION
This PR adds the feature of interpolated messages.

- [x] add a text inside the help message explaining the interpolation syntax

The interpolation syntax is the same one from KinoDB. One can write a slack interpolated message like this

![CleanShot 2023-03-10 at 14 27 34](https://user-images.githubusercontent.com/2719/224382850-d9c1a35b-0396-401a-ab1b-7eb41cd95fb7.png)
